### PR TITLE
Be more relaxed/lenient in handling attributes cardinality on load

### DIFF
--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectDeserializer.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectDeserializer.java
@@ -837,11 +837,26 @@ public class GsonEObjectDeserializer implements JsonDeserializer<List<EObject>> 
     private void deserializeEAttribute(EAttribute eAttribute, JsonElement jsonElement, EObject eObject) {
         EDataType dataType = eAttribute.getEAttributeType();
         if (!eAttribute.isMany()) {
-            String newValue = jsonElement.getAsString();
+            String newValue = null;
+            if (jsonElement.isJsonArray()) {
+                JsonArray asJsonArray = jsonElement.getAsJsonArray();
+                if (asJsonArray.size() > 0) {
+                    newValue = asJsonArray.get(0).getAsString();
+                }
+            }
+            if (newValue == null) {
+                newValue = jsonElement.getAsString();
+            }
             Object value = EcoreUtil.createFromString(dataType, newValue);
             this.helper.setValue(eObject, eAttribute, value);
         } else {
-            JsonArray asJsonArray = jsonElement.getAsJsonArray();
+            JsonArray asJsonArray;
+            if (jsonElement.isJsonPrimitive()) {
+                asJsonArray = new JsonArray();
+                asJsonArray.add(jsonElement.getAsString());
+            } else {
+                asJsonArray = jsonElement.getAsJsonArray();
+            }
             Object eGet = this.helper.getValue(eObject, eAttribute);
             if (eGet instanceof Collection<?>) {
                 for (JsonElement jElement : asJsonArray) {


### PR DESCRIPTION
The idea is to support the use case mentioned at https://github.com/eclipse-sirius/sirius-components/issues/615, i.e. loading a JSON resource when the metamodel has been modified in a specific way: an attribute which was single-valued at the time the model was serialized is now many-valued when reloading the resource (or vice versa).

The changes are relatively trivial: instead of blindly trusting the cardinality in the current (at load time) version of the metamodel, also check the kind of JSON value we have. If it matches, do as before. Otherwise:
* if we have a single primitive value in JSON but the attribute is now multi-valued, simply wrap the value in an array and proceed
* if we have a non-empty array in JSON but the attribute is now single-valued, unwrap the array and get the first element. In this case there can be some data loss as the additional values are not loaded and will not be re-serialized next time.

I have tested this with `EAttributes`, and it seems to work, at least on simple cases.

The same approach could probably be used for references too, i.e. when doing `String id = value.getAsString();` blindly in `deserializeSingleNonContainmentEReference()` and `JsonArray array = value.getAsJsonArray();` in `deserializeMultipleNonContainmentEReference()` for example.

Before proceeding I'd like @sbegaudeau  and @gcoutable's opinion on the general approach, and if this behavior should be controlled by a load option (probably) or not.
