### PR TITLE
Dev/marchesini 4

### DIFF
--- a/bundles/org.eclipse.sirius.emfjson/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.sirius.emfjson/META-INF/MANIFEST.MF
@@ -20,4 +20,3 @@ Import-Package: javax.xml.bind;version="0.0.0",
  org.eclipse.emf.ecore.resource.impl;version="0.0.0",
  org.eclipse.emf.ecore.util;version="0.0.0"
 Automatic-Module-Name: org.eclipse.sirius.emfjson
-Require-Bundle: javax.xml.bind;bundle-version="2.2.0"

--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResource.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResource.java
@@ -16,6 +16,7 @@ import com.google.gson.JsonElement;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Comparator;
 import java.util.Map;
 
 import org.eclipse.emf.common.util.URI;
@@ -417,6 +418,12 @@ public interface JsonResource extends Resource {
      * An option to provide an {@link IDManager} to handle the ID of an {@link EObject} in a resource.
      */
     String OPTION_ID_MANAGER = "OPTION_ID_MANAGER"; //$NON-NLS-1$
+
+    /**
+     * An option to provide a {@link Comparator} of {@link EStructuralFeature} to determine the order of the attributes
+     * in the serialized Json.
+     */
+    Object OPTION_SAVE_FEATURES_ORDER_COMPARATOR = "OPTION_SAVE_FEATURES_ORDER_COMPARATOR"; //$NON-NLS-1$
 
     /**
      * Associate an ID to the {@link EObject}.

--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectDeserializer.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectDeserializer.java
@@ -422,7 +422,9 @@ public class GsonEObjectDeserializer implements JsonDeserializer<List<EObject>> 
         if (properties != null) {
             Set<Entry<String, JsonElement>> entrySet = properties.entrySet();
             for (Entry<String, JsonElement> entry : entrySet) {
-                EStructuralFeature eStructuralFeature = eClass.getEStructuralFeature(entry.getKey());
+                EStructuralFeature eStructuralFeature = (this.extendedMetaData != null) ? //
+                        this.extendedMetaData.getElement(eClass, eClass.getEPackage().getNsURI(), entry.getKey()) : //
+                        eClass.getEStructuralFeature(entry.getKey());
 
                 if (eStructuralFeature instanceof EAttribute) {
                     this.deserializeEAttribute((EAttribute) eStructuralFeature, entry.getValue(), eObject);

--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectDeserializer.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectDeserializer.java
@@ -887,25 +887,39 @@ public class GsonEObjectDeserializer implements JsonDeserializer<List<EObject>> 
         EDataType dataType = eAttribute.getEAttributeType();
         if (!eAttribute.isMany()) {
             String newValue = this.getAsFlexibleString(jsonElement);
-            Object value;
-            try {
-                value = EcoreUtil.createFromString(dataType, newValue);
-            } catch (IllegalArgumentException e) {
-                value = newValue;
-            }
+            Object value = this.tryCreateDataTypeFromString(dataType, newValue);
             this.helper.setValue(eObject, eAttribute, value);
         } else {
             JsonArray asJsonArray = this.getAsFlexibleArray(jsonElement);
             Object eGet = this.helper.getValue(eObject, eAttribute);
             if (eGet instanceof Collection<?>) {
                 for (JsonElement jElement : asJsonArray) {
-                    Object value = EcoreUtil.createFromString(dataType, jElement.getAsString());
-                    @SuppressWarnings("unchecked")
-                    Collection<Object> collection = (Collection<Object>) eGet;
-                    collection.add(value);
+                    Object value = this.tryCreateDataTypeFromString(dataType, jElement.getAsString());
+                    this.helper.setValue(eObject, eAttribute, value);
                 }
             }
         }
+    }
+
+    /**
+     * Try to create a {@link EDataType} instance from a serialized form of the value. If the serialization is not
+     * compatible with the given EDataType, returns the serialized form of the value unchanged.
+     *
+     * @param dataType
+     *            The {@link EDataType} to instantiate
+     * @param serializedValue
+     *            The serialized form of the value
+     * @return A new EDataType instance or the given serializedValue if the EDataType could not be instantiated from the
+     *         serializedValue.
+     */
+    private Object tryCreateDataTypeFromString(EDataType dataType, String serializedValue) {
+        Object value;
+        try {
+            value = EcoreUtil.createFromString(dataType, serializedValue);
+        } catch (IllegalArgumentException e) {
+            value = serializedValue;
+        }
+        return value;
     }
 
     /**

--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectDeserializer.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectDeserializer.java
@@ -887,7 +887,12 @@ public class GsonEObjectDeserializer implements JsonDeserializer<List<EObject>> 
         EDataType dataType = eAttribute.getEAttributeType();
         if (!eAttribute.isMany()) {
             String newValue = this.getAsFlexibleString(jsonElement);
-            Object value = EcoreUtil.createFromString(dataType, newValue);
+            Object value;
+            try {
+                value = EcoreUtil.createFromString(dataType, newValue);
+            } catch (IllegalArgumentException e) {
+                value = newValue;
+            }
             this.helper.setValue(eObject, eAttribute, value);
         } else {
             JsonArray asJsonArray = this.getAsFlexibleArray(jsonElement);

--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectSerializer.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/GsonEObjectSerializer.java
@@ -25,12 +25,14 @@ import java.security.InvalidParameterException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -864,10 +866,18 @@ public class GsonEObjectSerializer implements JsonSerializer<List<EObject>> {
      *            The EObject to serialize
      * @return A JsonObject containing all the properties of the given object
      */
+    @SuppressWarnings("unchecked")
     private JsonObject serializeEAllStructuralFeatures(EObject eObject) {
         JsonObject properties = new JsonObject();
         EClass eClass = eObject.eClass();
-        EList<EStructuralFeature> eAllStructuralFeatures = eClass.getEAllStructuralFeatures();
+        List<EStructuralFeature> eAllStructuralFeatures = eClass.getEAllStructuralFeatures();
+
+        Object orderFeatures = this.options.get(JsonResource.OPTION_SAVE_FEATURES_ORDER_COMPARATOR);
+        if (orderFeatures instanceof Comparator<?>) {
+            eAllStructuralFeatures = eAllStructuralFeatures.stream() //
+                    .sorted((Comparator<? super EStructuralFeature>) orderFeatures) //
+                    .collect(Collectors.toList());
+        }
 
         for (EStructuralFeature eStructuralFeature : eAllStructuralFeatures) {
             if (this.shouldSerialize(eObject, eStructuralFeature)) {

--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/JsonHelper.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/JsonHelper.java
@@ -14,6 +14,7 @@
 package org.eclipse.sirius.emfjson.utils;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -581,7 +582,8 @@ public class JsonHelper {
     }
 
     /**
-     * Sets the value of the feature for the given object.
+     * Sets the value of the feature for the given object. If the feature is multivalued, add the value to the
+     * collection of values already set.
      *
      * @param object
      *            the given object
@@ -591,7 +593,13 @@ public class JsonHelper {
      *            the value to set
      */
     public void setValue(EObject object, EStructuralFeature feature, Object value) {
-        object.eSet(feature, value);
+        if (feature.isMany()) {
+            @SuppressWarnings("unchecked")
+            Collection<Object> collection = (Collection<Object>) object.eGet(feature);
+            collection.add(value);
+        } else {
+            object.eSet(feature, value);
+        }
     }
 
     /**

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/AbstractEMFJsonTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/AbstractEMFJsonTests.java
@@ -43,6 +43,7 @@ import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.emfjson.resource.JsonResourceFactoryImpl;
 import org.eclipse.sirius.emfjson.resource.JsonResourceImpl;
+import org.eclipse.sirius.emfjson.utils.JsonHelper;
 import org.junit.Assert;
 
 /**
@@ -276,6 +277,10 @@ public abstract class AbstractEMFJsonTests {
             resource = resourceSet.createResource(uri);
             String extension = resource.getURI().fileExtension();
             if (extension.equals(JsonResourceFactoryImpl.EXTENSION)) {
+                if (this.options.get(JsonResource.OPTION_CUSTOM_HELPER) instanceof JsonHelper) {
+                    JsonHelper jsonHelper = (JsonHelper) this.options.get(JsonResource.OPTION_CUSTOM_HELPER);
+                    jsonHelper.setResource(resource);
+                }
                 resource.load(inputStream, this.options);
             } else {
                 resource.load(inputStream, Collections.EMPTY_MAP);

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/DataTypeLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/DataTypeLoadTests.java
@@ -49,4 +49,20 @@ public class DataTypeLoadTests extends AbstractEMFJsonTests {
         this.testLoad("NodeMultipleCustomDataType.xmi"); //$NON-NLS-1$
     }
 
+    /**
+     * Test deserialization of POJO EDataType EAttribute monovalued.
+     */
+    @Test
+    public void testLoadSingleValueAttributePojoDataType() {
+        this.testLoad("NodeSingleValueAttributePojoDataType.xmi"); //$NON-NLS-1$
+    }
+
+    /**
+     * Test deserialization of POJO EDataType EAttribute multivalued.
+     */
+    @Test
+    public void testLoadMultiValuedAttributePojoDataType() {
+        this.testLoad("NodeMultiValuedAttributePojoDataType.xmi"); //$NON-NLS-1$
+    }
+
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataAttributesLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataAttributesLoadTests.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 /**
  * Tests loading with ExtendedMetaData.
  */
-public class ExtendedMetaDataLoadTests extends AbstractEMFJsonTests {
+public class ExtendedMetaDataAttributesLoadTests extends AbstractEMFJsonTests {
 
     /**
      * {@inheritDoc}
@@ -30,14 +30,14 @@ public class ExtendedMetaDataLoadTests extends AbstractEMFJsonTests {
      */
     @Override
     protected String getRootPath() {
-        return "/unit/attributes/extendedmetadata/"; //$NON-NLS-1$
+        return "/unit/references/extendedmetadata/"; //$NON-NLS-1$
     }
 
     /**
-     * Change the name of a monovalued EAttribute.
+     * Change the name of a monovalued EReference.
      */
     @Test
-    public void testChangeAttributeNameMono() {
+    public void testChangeReferenceNameMono() {
         // CHECKSTYLE:OFF
         ExtendedMetaData metaData = new BasicExtendedMetaData() {
 
@@ -49,23 +49,25 @@ public class ExtendedMetaDataLoadTests extends AbstractEMFJsonTests {
              */
             @Override
             public EStructuralFeature getElement(EClass eClass, String namespace, String name) {
-                if ("NodeSingleValueAttribute".equals(eClass.getName()) && "singleStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
-                    return eClass.getEStructuralFeature("singleStringAttribute"); //$NON-NLS-1$
+                if ("NodeSingleValueReference".equals(eClass.getName()) && "singleValuedReferenceOld".equals(name)) {
+                    // $NON-NLS-1$ //$NON-NLS-2$
+                    return eClass.getEStructuralFeature("singleValuedReference"); //$NON-NLS-1$
                 }
-                return super.getElement(eClass, namespace, name);
+                // return super.getElement(eClass, namespace, name); // Doesn't work
+                return eClass.getEStructuralFeature(name);
             }
 
         };
         // CHECKSTYLE:ON
         this.options.put(JsonResource.OPTION_EXTENDED_META_DATA, metaData);
-        this.testLoad("TestChangeAttributeNameMono.xmi"); //$NON-NLS-1$
+        this.testLoad("TestChangeReferenceNameMono.xmi"); //$NON-NLS-1$
     }
 
     /**
-     * Change the name of a multivalued EAttribute.
+     * Change the name of a multivalued EReference.
      */
     @Test
-    public void testChangeAttributeNameMulti() {
+    public void testChangeReferenceNameMulti() {
         // CHECKSTYLE:OFF
         ExtendedMetaData metaData = new BasicExtendedMetaData() {
 
@@ -80,13 +82,14 @@ public class ExtendedMetaDataLoadTests extends AbstractEMFJsonTests {
                 if ("NodeMultiValuedAttribute".equals(eClass.getName()) && "multiStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
                     return eClass.getEStructuralFeature("multiStringAttribute"); //$NON-NLS-1$
                 }
-                return super.getElement(eClass, namespace, name);
+                // return super.getElement(eClass, namespace, name); // Doesn't work
+                return eClass.getEStructuralFeature(name);
             }
 
         };
         // CHECKSTYLE:ON
         this.options.put(JsonResource.OPTION_EXTENDED_META_DATA, metaData);
-        this.testLoad("TestChangeAttributeNameMulti.xmi"); //$NON-NLS-1$
+        this.testLoad("TestChangeReferenceNameMulti.xmi"); //$NON-NLS-1$
     }
 
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataLoadTests.java
@@ -34,7 +34,7 @@ public class ExtendedMetaDataLoadTests extends AbstractEMFJsonTests {
     }
 
     /**
-     * Change the name of an EReference.
+     * Change the name of a monovalued EAttribute.
      */
     @Test
     public void testChangeAttributeNameMono() {
@@ -59,6 +59,34 @@ public class ExtendedMetaDataLoadTests extends AbstractEMFJsonTests {
         // CHECKSTYLE:ON
         this.options.put(JsonResource.OPTION_EXTENDED_META_DATA, metaData);
         this.testLoad("TestChangeAttributeNameMono.xmi"); //$NON-NLS-1$
+    }
+
+    /**
+     * Change the name of a multivalued EAttribute.
+     */
+    @Test
+    public void testChangeAttributeNameMulti() {
+        // CHECKSTYLE:OFF
+        ExtendedMetaData metaData = new BasicExtendedMetaData() {
+
+            /**
+             * {@inheritDoc}
+             *
+             * @see org.eclipse.emf.ecore.util.BasicExtendedMetaData#getElement(org.eclipse.emf.ecore.EClass,
+             *      java.lang.String, java.lang.String)
+             */
+            @Override
+            public EStructuralFeature getElement(EClass eClass, String namespace, String name) {
+                if ("NodeMultiValuedAttribute".equals(eClass.getName()) && "multiStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
+                    return eClass.getEStructuralFeature("multiStringAttribute"); //$NON-NLS-1$
+                }
+                return super.getElement(eClass, namespace, name);
+            }
+
+        };
+        // CHECKSTYLE:ON
+        this.options.put(JsonResource.OPTION_EXTENDED_META_DATA, metaData);
+        this.testLoad("TestChangeAttributeNameMulti.xmi"); //$NON-NLS-1$
     }
 
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataLoadTests.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.emfjson.tests.internal.unit.load;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.BasicExtendedMetaData;
+import org.eclipse.emf.ecore.util.ExtendedMetaData;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
+import org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests;
+import org.junit.Test;
+
+/**
+ * Tests loading with ExtendedMetaData.
+ */
+public class ExtendedMetaDataLoadTests extends AbstractEMFJsonTests {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests#getRootPath()
+     */
+    @Override
+    protected String getRootPath() {
+        return "/unit/attributes/extendedmetadata/"; //$NON-NLS-1$
+    }
+
+    /**
+     * Change the name of an EReference.
+     */
+    @Test
+    public void testChangeAttributeNameMono() {
+        // CHECKSTYLE:OFF
+        ExtendedMetaData metaData = new BasicExtendedMetaData() {
+
+            /**
+             * {@inheritDoc}
+             *
+             * @see org.eclipse.emf.ecore.util.BasicExtendedMetaData#getElement(org.eclipse.emf.ecore.EClass,
+             *      java.lang.String, java.lang.String)
+             */
+            @Override
+            public EStructuralFeature getElement(EClass eClass, String namespace, String name) {
+                if ("NodeSingleValueAttribute".equals(eClass.getName()) && "singleStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
+                    return eClass.getEStructuralFeature("singleStringAttribute"); //$NON-NLS-1$
+                }
+                return super.getElement(eClass, namespace, name);
+            }
+
+        };
+        // CHECKSTYLE:ON
+        this.options.put(JsonResource.OPTION_EXTENDED_META_DATA, metaData);
+        this.testLoad("TestChangeAttributeNameMono.xmi"); //$NON-NLS-1$
+    }
+
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataReferencesLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataReferencesLoadTests.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.emfjson.tests.internal.unit.load;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.BasicExtendedMetaData;
+import org.eclipse.emf.ecore.util.ExtendedMetaData;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
+import org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests;
+import org.junit.Test;
+
+/**
+ * Tests loading with ExtendedMetaData.
+ */
+public class ExtendedMetaDataReferencesLoadTests extends AbstractEMFJsonTests {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests#getRootPath()
+     */
+    @Override
+    protected String getRootPath() {
+        return "/unit/attributes/extendedmetadata/"; //$NON-NLS-1$
+    }
+
+    /**
+     * Change the name of a monovalued EAttribute.
+     */
+    @Test
+    public void testChangeAttributeNameMono() {
+        // CHECKSTYLE:OFF
+        ExtendedMetaData metaData = new BasicExtendedMetaData() {
+
+            /**
+             * {@inheritDoc}
+             *
+             * @see org.eclipse.emf.ecore.util.BasicExtendedMetaData#getElement(org.eclipse.emf.ecore.EClass,
+             *      java.lang.String, java.lang.String)
+             */
+            @Override
+            public EStructuralFeature getElement(EClass eClass, String namespace, String name) {
+                if ("NodeSingleValueAttribute".equals(eClass.getName()) && "singleStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
+                    return eClass.getEStructuralFeature("singleStringAttribute"); //$NON-NLS-1$
+                }
+                return super.getElement(eClass, namespace, name);
+            }
+
+        };
+        // CHECKSTYLE:ON
+        this.options.put(JsonResource.OPTION_EXTENDED_META_DATA, metaData);
+        this.testLoad("TestChangeAttributeNameMono.xmi"); //$NON-NLS-1$
+    }
+
+    /**
+     * Change the name of a multivalued EAttribute.
+     */
+    @Test
+    public void testChangeAttributeNameMulti() {
+        // CHECKSTYLE:OFF
+        ExtendedMetaData metaData = new BasicExtendedMetaData() {
+
+            /**
+             * {@inheritDoc}
+             *
+             * @see org.eclipse.emf.ecore.util.BasicExtendedMetaData#getElement(org.eclipse.emf.ecore.EClass,
+             *      java.lang.String, java.lang.String)
+             */
+            @Override
+            public EStructuralFeature getElement(EClass eClass, String namespace, String name) {
+                if ("NodeMultiValuedAttribute".equals(eClass.getName()) && "multiStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
+                    return eClass.getEStructuralFeature("multiStringAttribute"); //$NON-NLS-1$
+                }
+                return super.getElement(eClass, namespace, name);
+            }
+
+        };
+        // CHECKSTYLE:ON
+        this.options.put(JsonResource.OPTION_EXTENDED_META_DATA, metaData);
+        this.testLoad("TestChangeAttributeNameMulti.xmi"); //$NON-NLS-1$
+    }
+
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
@@ -122,4 +122,34 @@ public class JsonHelperDataLoadTests extends AbstractEMFJsonTests {
         this.testLoad("TestChangeAttributeValueMono.xmi"); //$NON-NLS-1$
     }
 
+    /**
+     * Change the value of a multivalued EAttribute.
+     */
+    @Test
+    public void testChangeAttributeValueMulti() {
+        // CHECKSTYLE:OFF
+        JsonHelper jsonHelper = new JsonHelper() {
+
+            /**
+             * {@inheritDoc}
+             *
+             * @see org.eclipse.sirius.emfjson.utils.JsonHelper#setValue(org.eclipse.emf.ecore.EObject,
+             *      org.eclipse.emf.ecore.EStructuralFeature, java.lang.Object)
+             */
+            @Override
+            public void setValue(EObject object, EStructuralFeature feature, Object value) {
+                Object newValue = value;
+                if ("NodeMultiValuedAttribute".equals(feature.getEContainingClass().getName()) && "multiStringAttribute".equals(feature.getName())) { //$NON-NLS-1$ //$NON-NLS-2$
+                    newValue = ((String) value).toUpperCase();
+                }
+                super.setValue(object, feature, newValue);
+            }
+
+        };
+
+        // CHECKSTYLE:ON
+        this.options.put(JsonResource.OPTION_CUSTOM_HELPER, jsonHelper);
+        this.testLoad("TestChangeAttributeValueMulti.xmi"); //$NON-NLS-1$
+    }
+
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
@@ -62,4 +62,34 @@ public class JsonHelperDataLoadTests extends AbstractEMFJsonTests {
         this.testLoad("TestChangeAttributeTypeMono.xmi"); //$NON-NLS-1$
     }
 
+    /**
+     * Change the type of a monovalued EAttribute.
+     */
+    @Test
+    public void testChangeAttributeTypeMulti() {
+        // CHECKSTYLE:OFF
+        JsonHelper jsonHelper = new JsonHelper() {
+
+            /**
+             * {@inheritDoc}
+             *
+             * @see org.eclipse.sirius.emfjson.utils.JsonHelper#setValue(org.eclipse.emf.ecore.EObject,
+             *      org.eclipse.emf.ecore.EStructuralFeature, java.lang.Object)
+             */
+            @Override
+            public void setValue(EObject object, EStructuralFeature feature, Object value) {
+                Object newValue = value;
+                if ("NodeMultiValuedAttribute".equals(feature.getEContainingClass().getName()) && "multiIntAttribute".equals(feature.getName())) { //$NON-NLS-1$ //$NON-NLS-2$
+                    newValue = new Integer(((String) value).length());
+                }
+                super.setValue(object, feature, newValue);
+            }
+
+        };
+
+        // CHECKSTYLE:ON
+        this.options.put(JsonResource.OPTION_CUSTOM_HELPER, jsonHelper);
+        this.testLoad("TestChangeAttributeTypeMulti.xmi"); //$NON-NLS-1$
+    }
+
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
@@ -92,4 +92,34 @@ public class JsonHelperDataLoadTests extends AbstractEMFJsonTests {
         this.testLoad("TestChangeAttributeTypeMulti.xmi"); //$NON-NLS-1$
     }
 
+    /**
+     * Change the value of a monovalued EAttribute.
+     */
+    @Test
+    public void testChangeAttributeValueMono() {
+        // CHECKSTYLE:OFF
+        JsonHelper jsonHelper = new JsonHelper() {
+
+            /**
+             * {@inheritDoc}
+             *
+             * @see org.eclipse.sirius.emfjson.utils.JsonHelper#setValue(org.eclipse.emf.ecore.EObject,
+             *      org.eclipse.emf.ecore.EStructuralFeature, java.lang.Object)
+             */
+            @Override
+            public void setValue(EObject object, EStructuralFeature feature, Object value) {
+                Object newValue = value;
+                if ("NodeSingleValueAttribute".equals(feature.getEContainingClass().getName()) && "singleStringAttribute".equals(feature.getName())) { //$NON-NLS-1$ //$NON-NLS-2$
+                    newValue = ((String) value).toUpperCase();
+                }
+                super.setValue(object, feature, newValue);
+            }
+
+        };
+
+        // CHECKSTYLE:ON
+        this.options.put(JsonResource.OPTION_CUSTOM_HELPER, jsonHelper);
+        this.testLoad("TestChangeAttributeValueMono.xmi"); //$NON-NLS-1$
+    }
+
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.emfjson.tests.internal.unit.load;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
+import org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests;
+import org.eclipse.sirius.emfjson.utils.JsonHelper;
+import org.junit.Test;
+
+/**
+ * Tests loading with ExtendedMetaData.
+ */
+public class JsonHelperDataLoadTests extends AbstractEMFJsonTests {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests#getRootPath()
+     */
+    @Override
+    protected String getRootPath() {
+        return "/unit/attributes/extendedmetadata/"; //$NON-NLS-1$
+    }
+
+    /**
+     * Change the type of a monovalued EAttribute.
+     */
+    @Test
+    public void testChangeAttributeTypeMono() {
+        // CHECKSTYLE:OFF
+        JsonHelper jsonHelper = new JsonHelper() {
+
+            /**
+             * {@inheritDoc}
+             *
+             * @see org.eclipse.sirius.emfjson.utils.JsonHelper#setValue(org.eclipse.emf.ecore.EObject,
+             *      org.eclipse.emf.ecore.EStructuralFeature, java.lang.Object)
+             */
+            @Override
+            public void setValue(EObject object, EStructuralFeature feature, Object value) {
+                Object newValue = value;
+                if ("NodeSingleValueAttribute".equals(feature.getEContainingClass().getName()) && "singleIntAttribute".equals(feature.getName())) { //$NON-NLS-1$ //$NON-NLS-2$
+                    newValue = new Integer(((String) value).length());
+                }
+                super.setValue(object, feature, newValue);
+            }
+
+        };
+
+        // CHECKSTYLE:ON
+        this.options.put(JsonResource.OPTION_CUSTOM_HELPER, jsonHelper);
+        this.testLoad("TestChangeAttributeTypeMono.xmi"); //$NON-NLS-1$
+    }
+
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/save/DataTypeSaveTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/save/DataTypeSaveTests.java
@@ -49,4 +49,20 @@ public class DataTypeSaveTests extends AbstractEMFJsonTests {
         this.testSave("NodeMultipleCustomDataType.xmi"); //$NON-NLS-1$
     }
 
+    /**
+     * Test serialization of POJO EDataType EAttribute monovalued.
+     */
+    @Test
+    public void testSaveSingleValueAttributePojoDataType() {
+        this.testSave("NodeSingleValueAttributePojoDataType.xmi"); //$NON-NLS-1$
+    }
+
+    /**
+     * Test serialization of POJO EDataType EAttribute multivalued.
+     */
+    @Test
+    public void testSaveMultiValuedAttributePojoDataType() {
+        this.testSave("NodeMultiValuedAttributePojoDataType.xmi"); //$NON-NLS-1$
+    }
+
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/save/SerializeOptionsTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/save/SerializeOptionsTests.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Map;
 
 import org.eclipse.emf.common.util.BasicEList;
@@ -450,4 +451,24 @@ public class SerializeOptionsTests extends AbstractEMFJsonTests {
         this.testSave("SimpleModelWithOnlyDefaultValueForResourceHandlerPreSavingTest.xmi"); //$NON-NLS-1$
 
     }
+
+    /**
+     * Test the serialization with feature order comparator.
+     */
+    @Test
+    public void testSerializationWithFeatureOrderComparator() {
+
+        // A comparator to sort the feature on their name length.
+        Comparator<EStructuralFeature> featuresComparator = new Comparator<EStructuralFeature>() {
+            @Override
+            public int compare(EStructuralFeature o1, EStructuralFeature o2) {
+                return o1.getName().length() - o2.getName().length();
+            }
+        };
+
+        this.options.put(JsonResource.OPTION_SAVE_FEATURES_ORDER_COMPARATOR, featuresComparator);
+        this.testSave("TestSerializationWithFeatureOrderComparator.xmi"); //$NON-NLS-1$
+
+    }
+
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/model/TestPojoDataTypeImpl.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/model/TestPojoDataTypeImpl.java
@@ -1,0 +1,166 @@
+package model;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo. All rights reserved. This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: Obeo - initial API and implementation
+ *******************************************************************************/
+
+public class TestPojoDataTypeImpl {
+
+    /**
+     * A String value.
+     */
+    private String stringValue = null;
+
+    /**
+     * An integer value.
+     */
+    private int intValue = 0;
+
+    /**
+     * Not serialized.
+     */
+    private transient int transientIntValue = 0;
+
+    /**
+     * Empty constructor for Json serialization.
+     *
+     */
+    public TestPojoDataTypeImpl() {
+
+    }
+
+    /**
+     * Returns the stringValue.
+     *
+     * @return The stringValue
+     */
+    public String getStringValue() {
+        return this.stringValue;
+    }
+
+    /**
+     * Sets the stringValue.
+     *
+     * @param stringValue
+     *            The stringValue to set
+     */
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    /**
+     * Returns the intValue.
+     *
+     * @return The intValue
+     */
+    public int getIntValue() {
+        return this.intValue;
+    }
+
+    /**
+     * Sets the intValue.
+     *
+     * @param intValue
+     *            The intValue to set
+     */
+    public void setIntValue(int intValue) {
+        this.intValue = intValue;
+    }
+
+    /**
+     * Returns the transientIntValue.
+     *
+     * @return The transientIntValue
+     */
+    public int getTransientIntValue() {
+        return this.transientIntValue;
+    }
+
+    /**
+     * Sets the transientIntValue.
+     *
+     * @param transientIntValue
+     *            The transientIntValue to set
+     */
+    public void setTransientIntValue(int transientIntValue) {
+        this.transientIntValue = transientIntValue;
+    }
+
+    /**
+     * Used by the XMI serialization. This doesn't produce as a Json string on purpose, not to interfere with the Json
+     * serialization.<br>
+     *
+     * @return A string representing this {@link TestPojoDataTypeImpl} instance.
+     */
+    @Override
+    public String toString() {
+        return String.format("TestPojoDataTypeImpl('%s', %d)", this.stringValue.replaceAll("'", "&apos;"), Integer.valueOf(this.intValue)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    /**
+     * Used by the XMI deserialization. This doesn't take a Json string on purpose, not to interfere with the Json
+     * deserialization.
+     *
+     * @param serialized
+     *            The serialized form of a {@link TestPojoDataTypeImpl} as produced by
+     *            {@link TestPojoDataTypeImpl#toString()}.
+     * @return A new instance of {@link TestPojoDataTypeImpl} if the given serialized form is consistent, null
+     *         otherwise.
+     */
+    public static TestPojoDataTypeImpl valueOf(String serialized) {
+        TestPojoDataTypeImpl value = null;
+        Matcher matcher = Pattern.compile("TestPojoDataTypeImpl\\('([^']*)', ([0-9]+)\\)").matcher(serialized); //$NON-NLS-1$
+        if (matcher.matches()) {
+            value = new TestPojoDataTypeImpl();
+            value.setStringValue(matcher.group(1).replaceAll("&apos;", "'")); //$NON-NLS-1$ //$NON-NLS-2$
+            value.setIntValue(Integer.parseInt(matcher.group(2)));
+        }
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + this.intValue;
+        result = prime * result + ((this.stringValue == null) ? 0 : this.stringValue.hashCode());
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (this.getClass() != obj.getClass())
+            return false;
+        TestPojoDataTypeImpl other = (TestPojoDataTypeImpl) obj;
+        if (this.intValue != other.intValue)
+            return false;
+        if (this.stringValue == null) {
+            if (other.stringValue != null)
+                return false;
+        } else if (!this.stringValue.equals(other.stringValue))
+            return false;
+        return true;
+    }
+
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/nodes.ecore
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/nodes.ecore
@@ -61,6 +61,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="singleShortAttribute" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EShort"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="singleShortObjectAttribute"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EShortObject"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="singleTestPojoDataTypeAttribute"
+        eType="#//TestPojoDataType"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NodeMultiValuedAttribute" eSuperTypes="#//Node">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiStringAttribute" upperBound="-1"
@@ -105,6 +107,8 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EShort"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiShortObjectAttribute"
         upperBound="-1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EShortObject"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiPojoDataTypeAttribute"
+        upperBound="-1" eType="#//TestPojoDataType"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NodeSingleValueReference" eSuperTypes="#//Node">
     <eStructuralFeatures xsi:type="ecore:EReference" name="singleValuedReference"
@@ -171,4 +175,5 @@
   <eClassifiers xsi:type="ecore:EClass" name="OtherClass">
     <eTypeParameters name="aTypeParameter"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="TestPojoDataType" instanceClassName="model.TestPojoDataTypeImpl"/>
 </ecore:EPackage>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeMultiValuedAttributePojoDataType.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeMultiValuedAttributePojoDataType.json
@@ -1,0 +1,33 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeMultiValuedAttribute",
+      "data": {
+        "multiPojoDataTypeAttribute": [
+          {
+            "stringValue": "Eleven",
+            "intValue": 11
+          },
+          {
+            "stringValue": "Twelve",
+            "intValue": 12
+          },
+          {
+            "stringValue": "Forty two",
+            "intValue": 42
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeMultiValuedAttributePojoDataType.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeMultiValuedAttributePojoDataType.xmi
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeMultiValuedAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore">
+  <multiPojoDataTypeAttribute>TestPojoDataTypeImpl('Eleven', 11)</multiPojoDataTypeAttribute>
+  <multiPojoDataTypeAttribute>TestPojoDataTypeImpl('Twelve', 12)</multiPojoDataTypeAttribute>
+  <multiPojoDataTypeAttribute>TestPojoDataTypeImpl('Forty two', 42)</multiPojoDataTypeAttribute>
+</nodes:NodeMultiValuedAttribute>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeSingleValueAttributePojoDataType.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeSingleValueAttributePojoDataType.json
@@ -1,0 +1,23 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeSingleValueAttribute",
+      "data": {
+        "singleTestPojoDataTypeAttribute": {
+          "stringValue": "Twelve",
+          "intValue": 12
+        }
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeSingleValueAttributePojoDataType.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeSingleValueAttributePojoDataType.xmi
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeSingleValueAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore"
+    singleTestPojoDataTypeAttribute="TestPojoDataTypeImpl('Twelve', 12)"/>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeNameMono.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeNameMono.json
@@ -1,0 +1,21 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "emfjson": "http://obeo.fr/emfjson",
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeSingleValueAttribute",
+      "data": {
+        "singleStringAttributeOld": "singleStringAttribute value"
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeNameMono.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeNameMono.xmi
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeSingleValueAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore"
+    singleStringAttribute="singleStringAttribute value"/>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeNameMulti.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeNameMulti.json
@@ -1,0 +1,25 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "emfjson": "http://obeo.fr/emfjson",
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeMultiValuedAttribute",
+      "data": {
+        "multiStringAttributeOld": [ 
+			"multiStringAttribute value 1", 
+			"multiStringAttribute value 2", 
+			"multiStringAttribute value 3" 
+		]
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeNameMulti.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeNameMulti.xmi
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeMultiValuedAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore">
+  <multiStringAttribute>multiStringAttribute value 1</multiStringAttribute>
+  <multiStringAttribute>multiStringAttribute value 2</multiStringAttribute>
+  <multiStringAttribute>multiStringAttribute value 3</multiStringAttribute>
+</nodes:NodeMultiValuedAttribute>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeTypeMono.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeTypeMono.json
@@ -1,0 +1,21 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "emfjson": "http://obeo.fr/emfjson",
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeSingleValueAttribute",
+      "data": {
+        "singleIntAttribute": "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeTypeMono.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeTypeMono.xmi
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeSingleValueAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore"
+    singleIntAttribute="26"/>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeTypeMulti.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeTypeMulti.json
@@ -1,0 +1,25 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "emfjson": "http://obeo.fr/emfjson",
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeMultiValuedAttribute",
+      "data": {
+        "multiIntAttribute": [ 
+			"ABC", 
+			"ABCDEF", 
+			"ABCDEFGHI" 
+		]
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeTypeMulti.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeTypeMulti.xmi
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeMultiValuedAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore">
+  <multiIntAttribute>3</multiIntAttribute>
+  <multiIntAttribute>6</multiIntAttribute>
+  <multiIntAttribute>9</multiIntAttribute>
+</nodes:NodeMultiValuedAttribute>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeValueMono.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeValueMono.json
@@ -1,0 +1,21 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "emfjson": "http://obeo.fr/emfjson",
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeSingleValueAttribute",
+      "data": {
+        "singleStringAttribute": "singleStringAttribute value"
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeValueMono.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeValueMono.xmi
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeSingleValueAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore"
+    singleStringAttribute="SINGLESTRINGATTRIBUTE VALUE"/>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeValueMulti.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeValueMulti.json
@@ -1,0 +1,25 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "emfjson": "http://obeo.fr/emfjson",
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeMultiValuedAttribute",
+      "data": {
+        "multiStringAttribute": [ 
+			"abc", 
+			"abcdef", 
+			"abcdefghi" 
+		]
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeValueMulti.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/extendedmetadata/TestChangeAttributeValueMulti.xmi
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeMultiValuedAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore">
+  <multiStringAttribute>ABC</multiStringAttribute>
+  <multiStringAttribute>ABCDEF</multiStringAttribute>
+  <multiStringAttribute>ABCDEFGHI</multiStringAttribute>
+</nodes:NodeMultiValuedAttribute>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/serializeoptions/TestSerializationWithFeatureOrderComparator.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/serializeoptions/TestSerializationWithFeatureOrderComparator.json
@@ -1,0 +1,22 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeSingleValueAttribute",
+      "data": {
+        "singleIntAttribute": 12,
+        "singleStringAttribute": "String value",
+        "singleBooleanAttribute": true
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/serializeoptions/TestSerializationWithFeatureOrderComparator.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/serializeoptions/TestSerializationWithFeatureOrderComparator.xmi
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeSingleValueAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore"
+    singleBooleanAttribute="true"
+    singleIntAttribute="12"
+    singleStringAttribute="String value"/>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/references/extendedmetadata/TestChangeReferenceNameMono.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/references/extendedmetadata/TestChangeReferenceNameMono.json
@@ -1,0 +1,27 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeSingleValueReference",
+      "data": {
+        "name": "Node1",
+        "singleValuedReferenceOld": "Node2"
+      }
+    },
+    {
+      "eClass": "nodes:NodeSingleValueReference",
+      "data": {
+        "name": "Node2"
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/references/extendedmetadata/TestChangeReferenceNameMono.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/references/extendedmetadata/TestChangeReferenceNameMono.xmi
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="ASCII"?>
+<xmi:XMI xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore">
+  <nodes:NodeSingleValueReference
+      name="Node1"
+      singleValuedReference="Node2"/>
+  <nodes:NodeSingleValueReference
+      name="Node2"/>
+</xmi:XMI>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/references/extendedmetadata/TestChangeReferenceNameMulti.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/references/extendedmetadata/TestChangeReferenceNameMulti.json
@@ -1,0 +1,36 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeMultiValuedReference",
+      "data": {
+        "name": "Node1",
+        "multiValuedReference": [
+          "Node2",
+          "Node3"
+         ]
+      }
+    },
+    {
+      "eClass": "nodes:NodeMultiValuedReference",
+      "data": {
+        "name": "Node2"
+      }
+    },
+    {
+      "eClass": "nodes:NodeMultiValuedReference",
+      "data": {
+        "name": "Node3"
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/references/extendedmetadata/TestChangeReferenceNameMulti.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/references/extendedmetadata/TestChangeReferenceNameMulti.xmi
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="ASCII"?>
+<xmi:XMI xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore">
+  <nodes:NodeMultiValuedReference
+      name="Node1"
+      multiValuedReference="Node2 Node3"/>
+  <nodes:NodeMultiValuedReference
+      name="Node2"/>
+  <nodes:NodeMultiValuedReference
+      name="Node3"/>
+</xmi:XMI>


### PR DESCRIPTION
Addresses the following subjects:

- Handling the renaming of EAttribute
Renaming of EAttribute is handled by the `ExtendedMetaData.getElement()` API. Examples of such a migration is provided in the `org.eclipse.sirius.emfjson.tests.internal.unit.load.ExtendedMetaDataAttributesLoadTests` test class.

- Handling a type change or a value change of an EAttribute
Changing the type or the value of an EAttribute is handled with the `JsonHelper.setValue()` API. Exemple of such migrations are provided in the `org.eclipse.sirius.emfjson.tests.internal.unit.load.JsonHelperDataLoadTests` test class.

- Support for Serialization / deserialization of POJO EDataType
Custom data types with instance type set to a POJO class are serialized to / deserialized from json. The corresponding tests are :
`org.eclipse.sirius.emfjson.tests.internal.unit.load.DataTypeLoadTests.testLoadSingleValueAttributePojoDataType()`
`org.eclipse.sirius.emfjson.tests.internal.unit.load.DataTypeLoadTests.testLoadMultiValuedAttributePojoDataType()`
`org.eclipse.sirius.emfjson.tests.internal.unit.save.DataTypeSaveTests.testSaveSingleValueAttributePojoDataType()`
`org.eclipse.sirius.emfjson.tests.internal.unit.save.DataTypeSaveTests.testSaveMultiValuedAttributePojoDataType()`

- A comparator option on the JsonResource to determine the order in which features are serialized
