### PR TITLE
[22] Support Metamodel migration, POJO datatype and feature serialization ordering

### DIFF
--- a/bundles/org.eclipse.sirius.emfjson.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.sirius.emfjson.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.sirius.emfjson.ide;singleton:=true
-Bundle-Version: 2.3.8.qualifier
+Bundle-Version: 2.3.9.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: bundle
 Require-Bundle: org.eclipse.sirius.emfjson;bundle-version="2.1.0",

--- a/bundles/org.eclipse.sirius.emfjson.ide/pom.xml
+++ b/bundles/org.eclipse.sirius.emfjson.ide/pom.xml
@@ -18,13 +18,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.8-SNAPSHOT</version>
+		<version>2.3.9-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 	
 	
 	<artifactId>org.eclipse.sirius.emfjson.ide</artifactId>
-	<version>2.3.8-SNAPSHOT</version>
+	<version>2.3.9-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	
 	<name>Sirius EMF JSON - IDE Integration</name>

--- a/bundles/org.eclipse.sirius.emfjson/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.sirius.emfjson/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.sirius.emfjson
-Bundle-Version: 2.3.8.qualifier
+Bundle-Version: 2.3.9.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: bundle

--- a/bundles/org.eclipse.sirius.emfjson/pom.xml
+++ b/bundles/org.eclipse.sirius.emfjson/pom.xml
@@ -18,13 +18,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.8-SNAPSHOT</version>
+		<version>2.3.9-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 	
 	
 	<artifactId>org.eclipse.sirius.emfjson</artifactId>
-	<version>2.3.8-SNAPSHOT</version>
+	<version>2.3.9-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	
 	<name>Sirius EMF JSON</name>

--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResource.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResource.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.emfjson.resource;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
@@ -19,8 +20,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
@@ -426,6 +429,12 @@ public interface JsonResource extends Resource {
      * in the serialized Json.
      */
     Object OPTION_SAVE_FEATURES_ORDER_COMPARATOR = "OPTION_SAVE_FEATURES_ORDER_COMPARATOR"; //$NON-NLS-1$
+
+    /**
+      * Specify a {@link Predicate} evaluating to true if a given {@link EDataType} should be serialized to/from Json
+      * with {@link Gson}.
+      */
+     String OPTION_SHOULD_EDATATYPE_BE_SERIALIZED_IN_JSON_PREDICATE = "shouldEDataTypeBeSerializedInJsonPredicate"; //$NON-NLS-1$
 
     /**
      * An option to provide an ISerializationListener.

--- a/features/org.eclipse.sirius.emfjson.feature.ide/feature.xml
+++ b/features/org.eclipse.sirius.emfjson.feature.ide/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sirius.emfjson.feature.ide"
       label="%Feature-name"
-      version="2.3.8.qualifier"
+      version="2.3.9.qualifier"
       provider-name="%Feature-vendor">
 
    <description url="">

--- a/features/org.eclipse.sirius.emfjson.feature.ide/pom.xml
+++ b/features/org.eclipse.sirius.emfjson.feature.ide/pom.xml
@@ -20,13 +20,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.8-SNAPSHOT</version>
+		<version>2.3.9-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 	
 	
 	<artifactId>org.eclipse.sirius.emfjson.feature.ide</artifactId>
-	<version>2.3.8-SNAPSHOT</version>
+	<version>2.3.9-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 	
 	<name>Sirius EMF JSON - IDE Integration Feature</name>

--- a/features/org.eclipse.sirius.emfjson.feature/feature.xml
+++ b/features/org.eclipse.sirius.emfjson.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sirius.emfjson.feature"
       label="%Feature-name"
-      version="2.3.8.qualifier"
+      version="2.3.9.qualifier"
       provider-name="%Feature-vendor">
 
    <description url="">

--- a/features/org.eclipse.sirius.emfjson.feature/pom.xml
+++ b/features/org.eclipse.sirius.emfjson.feature/pom.xml
@@ -20,13 +20,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.8-SNAPSHOT</version>
+		<version>2.3.9-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 
 
 	<artifactId>org.eclipse.sirius.emfjson.feature</artifactId>
-	<version>2.3.8-SNAPSHOT</version>
+	<version>2.3.9-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Sirius EMF JSON Feature</name>

--- a/releng/org.eclipse.sirius.emfjson.releng/pom.xml
+++ b/releng/org.eclipse.sirius.emfjson.releng/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.eclipse.sirius.emfjson</groupId>
   <artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-  <version>2.3.8-SNAPSHOT</version>
+  <version>2.3.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Sirius EMF JSON</name>

--- a/releng/org.eclipse.sirius.emfjson.targetplatforms/2019-06/pom.xml
+++ b/releng/org.eclipse.sirius.emfjson.targetplatforms/2019-06/pom.xml
@@ -6,13 +6,13 @@
  <parent>
     <groupId>org.eclipse.sirius.emfjson</groupId>
   	<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-  	<version>2.3.8-SNAPSHOT</version>
+  	<version>2.3.9-SNAPSHOT</version>
     <relativePath>../../org.eclipse.sirius.emfjson.releng</relativePath>
   </parent>
 
   <groupId>org.eclipse.sirius.emfjson</groupId>
   <artifactId>emfjson-2019-06</artifactId>
-  <version>2.3.8-SNAPSHOT</version>
+  <version>2.3.9-SNAPSHOT</version>
   <packaging>eclipse-target-definition</packaging>
 
 </project>

--- a/releng/org.eclipse.sirius.emfjson.targetplatforms/luna/pom.xml
+++ b/releng/org.eclipse.sirius.emfjson.targetplatforms/luna/pom.xml
@@ -6,13 +6,13 @@
  <parent>
     <groupId>org.eclipse.sirius.emfjson</groupId>
   	<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-  	<version>2.3.8-SNAPSHOT</version>
+  	<version>2.3.9-SNAPSHOT</version>
     <relativePath>../../org.eclipse.sirius.emfjson.releng</relativePath>
   </parent>
 
   <groupId>org.eclipse.sirius.emfjson</groupId>
   <artifactId>emfjson-luna</artifactId>
-  <version>2.3.8-SNAPSHOT</version>
+  <version>2.3.9-SNAPSHOT</version>
   <packaging>eclipse-target-definition</packaging>
 
 </project>

--- a/repositories/org.eclipse.sirius.emfjson.repository/pom.xml
+++ b/repositories/org.eclipse.sirius.emfjson.repository/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.8-SNAPSHOT</version>
+		<version>2.3.9-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 

--- a/tests/org.eclipse.sirius.emfjson.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.sirius.emfjson.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.sirius.emfjson.tests
-Bundle-Version: 2.3.8.qualifier
+Bundle-Version: 2.3.9.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: bundle

--- a/tests/org.eclipse.sirius.emfjson.tests/pom.xml
+++ b/tests/org.eclipse.sirius.emfjson.tests/pom.xml
@@ -20,13 +20,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.8-SNAPSHOT</version>
+		<version>2.3.9-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 
 
 	<artifactId>org.eclipse.sirius.emfjson.tests</artifactId>
-	<version>2.3.8-SNAPSHOT</version>
+	<version>2.3.9-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<name>Sirius EMF JSON - Tests</name>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/DataTypeLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/DataTypeLoadTests.java
@@ -13,8 +13,14 @@
 
 package org.eclipse.sirius.emfjson.tests.internal.unit.load;
 
+import java.util.function.Predicate;
+
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests;
 import org.junit.Test;
+
+import model.TestPojoDataTypeImpl;
 
 /**
  * Tests class for EDataType deserialization.
@@ -47,6 +53,38 @@ public class DataTypeLoadTests extends AbstractEMFJsonTests {
     @Test
     public void testMultipleSerialiationDataType() {
         this.testLoad("NodeMultipleCustomDataType.xmi"); //$NON-NLS-1$
+    }
+
+    /**
+     * Test deserialization of POJO EDataType EAttribute monovalued.
+     */
+    @Test
+    public void testLoadSingleValueAttributePojoDataType() {
+        Predicate<EDataType> eDataTypeJsonSerializableTester = new Predicate<EDataType>() {
+            @Override
+            public boolean test(EDataType eDataType) {
+                return eDataType.getInstanceClass() == TestPojoDataTypeImpl.class;
+            }
+        };
+        this.options.put(JsonResource.OPTION_SHOULD_EDATATYPE_BE_SERIALIZED_IN_JSON_PREDICATE, eDataTypeJsonSerializableTester);
+
+        this.testLoad("NodeSingleValueAttributePojoDataType.xmi"); //$NON-NLS-1$
+    }
+
+    /**
+     * Test deserialization of POJO EDataType EAttribute multivalued.
+     */
+    @Test
+    public void testLoadMultiValuedAttributePojoDataType() {
+        Predicate<EDataType> eDataTypeJsonSerializableTester = new Predicate<EDataType>() {
+            @Override
+            public boolean test(EDataType eDataType) {
+                return eDataType.getInstanceClass() == TestPojoDataTypeImpl.class;
+            }
+        };
+        this.options.put(JsonResource.OPTION_SHOULD_EDATATYPE_BE_SERIALIZED_IN_JSON_PREDICATE, eDataTypeJsonSerializableTester);
+
+        this.testLoad("NodeMultiValuedAttributePojoDataType.xmi"); //$NON-NLS-1$
     }
 
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataAttributesLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataAttributesLoadTests.java
@@ -45,7 +45,8 @@ public class ExtendedMetaDataAttributesLoadTests extends AbstractEMFJsonTests {
                     // $NON-NLS-1$ //$NON-NLS-2$
                     return eClass.getEStructuralFeature("singleValuedReference"); //$NON-NLS-1$
                 }
-                // return super.getElement(eClass, namespace, name); // Doesn't work
+                // return super.getElement(eClass, namespace, name); // Doesn't work because the super implementation in
+                // Ecore ends up checking that the string is XMI
                 return eClass.getEStructuralFeature(name);
             }
         };
@@ -65,7 +66,8 @@ public class ExtendedMetaDataAttributesLoadTests extends AbstractEMFJsonTests {
                 if ("NodeMultiValuedAttribute".equals(eClass.getName()) && "multiStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
                     return eClass.getEStructuralFeature("multiStringAttribute"); //$NON-NLS-1$
                 }
-                // return super.getElement(eClass, namespace, name); // Doesn't work
+                // return super.getElement(eClass, namespace, name); // Doesn't work because the super implementation in
+                // Ecore ends up checking that the string is XMI
                 return eClass.getEStructuralFeature(name);
             }
         };

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataReferencesLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/ExtendedMetaDataReferencesLoadTests.java
@@ -44,7 +44,9 @@ public class ExtendedMetaDataReferencesLoadTests extends AbstractEMFJsonTests {
                 if ("NodeSingleValueAttribute".equals(eClass.getName()) && "singleStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
                     return eClass.getEStructuralFeature("singleStringAttribute"); //$NON-NLS-1$
                 }
-                return super.getElement(eClass, namespace, name);
+                // return super.getElement(eClass, namespace, name); // Doesn't work because the super implementation in
+                // Ecore ends up checking that the string is XMI
+                return eClass.getEStructuralFeature(name);
             }
 
         };
@@ -71,7 +73,9 @@ public class ExtendedMetaDataReferencesLoadTests extends AbstractEMFJsonTests {
                 if ("NodeMultiValuedAttribute".equals(eClass.getName()) && "multiStringAttributeOld".equals(name)) { //$NON-NLS-1$ //$NON-NLS-2$
                     return eClass.getEStructuralFeature("multiStringAttribute"); //$NON-NLS-1$
                 }
-                return super.getElement(eClass, namespace, name);
+                // return super.getElement(eClass, namespace, name); // Doesn't work because the super implementation in
+                // Ecore ends up checking that the string is XMI
+                return eClass.getEStructuralFeature(name);
             }
 
         };

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/load/JsonHelperDataLoadTests.java
@@ -10,12 +10,17 @@
  *******************************************************************************/
 package org.eclipse.sirius.emfjson.tests.internal.unit.load;
 
+import java.util.function.Predicate;
+
+import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests;
 import org.eclipse.sirius.emfjson.utils.JsonHelper;
 import org.junit.Test;
+
+import model.TestPojoDataTypeImpl;
 
 /**
  * Tests loading with ExtendedMetaData.
@@ -42,13 +47,21 @@ public class JsonHelperDataLoadTests extends AbstractEMFJsonTests {
             public void setValue(EObject object, EStructuralFeature feature, Object value) {
                 Object newValue = value;
                 if ("NodeSingleValueAttribute".equals(feature.getEContainingClass().getName()) && "singleIntAttribute".equals(feature.getName())) { //$NON-NLS-1$ //$NON-NLS-2$
-                    newValue = new Integer(((String) value).length());
+                    newValue = Integer.valueOf(((String) value).length());
                 }
                 super.setValue(object, feature, newValue);
             }
         };
-
         this.options.put(JsonResource.OPTION_CUSTOM_HELPER, jsonHelper);
+
+        Predicate<EDataType> eDataTypeJsonSerializableTester = new Predicate<EDataType>() {
+            @Override
+            public boolean test(EDataType eDataType) {
+                return eDataType.getInstanceClass() == TestPojoDataTypeImpl.class;
+            }
+        };
+        this.options.put(JsonResource.OPTION_SHOULD_EDATATYPE_BE_SERIALIZED_IN_JSON_PREDICATE, eDataTypeJsonSerializableTester);
+
         this.testLoad("TestChangeAttributeTypeMono.xmi"); //$NON-NLS-1$
     }
 
@@ -62,7 +75,7 @@ public class JsonHelperDataLoadTests extends AbstractEMFJsonTests {
             public void setValue(EObject object, EStructuralFeature feature, Object value) {
                 Object newValue = value;
                 if ("NodeMultiValuedAttribute".equals(feature.getEContainingClass().getName()) && "multiIntAttribute".equals(feature.getName())) { //$NON-NLS-1$ //$NON-NLS-2$
-                    newValue = new Integer(((String) value).length());
+                    newValue = Integer.valueOf(((String) value).length());
                 }
                 super.setValue(object, feature, newValue);
             }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/save/DataTypeSaveTests.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/java/org/eclipse/sirius/emfjson/tests/internal/unit/save/DataTypeSaveTests.java
@@ -13,8 +13,14 @@
 
 package org.eclipse.sirius.emfjson.tests.internal.unit.save;
 
+import java.util.function.Predicate;
+
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.emfjson.tests.internal.AbstractEMFJsonTests;
 import org.junit.Test;
+
+import model.TestPojoDataTypeImpl;
 
 /**
  * Tests class for EDataType serialization.
@@ -47,6 +53,38 @@ public class DataTypeSaveTests extends AbstractEMFJsonTests {
     @Test
     public void testMultipleSerialiationDataType() {
         this.testSave("NodeMultipleCustomDataType.xmi"); //$NON-NLS-1$
+    }
+
+    /**
+     * Test serialization of POJO EDataType EAttribute monovalued.
+     */
+    @Test
+    public void testSaveSingleValueAttributePojoDataType() {
+        Predicate<EDataType> eDataTypeJsonSerializableTester = new Predicate<EDataType>() {
+            @Override
+            public boolean test(EDataType eDataType) {
+                return eDataType.getInstanceClass() == TestPojoDataTypeImpl.class;
+            }
+        };
+        this.options.put(JsonResource.OPTION_SHOULD_EDATATYPE_BE_SERIALIZED_IN_JSON_PREDICATE, eDataTypeJsonSerializableTester);
+
+        this.testSave("NodeSingleValueAttributePojoDataType.xmi"); //$NON-NLS-1$
+    }
+
+    /**
+     * Test serialization of POJO EDataType EAttribute multivalued.
+     */
+    @Test
+    public void testSaveMultiValuedAttributePojoDataType() {
+        Predicate<EDataType> eDataTypeJsonSerializableTester = new Predicate<EDataType>() {
+            @Override
+            public boolean test(EDataType eDataType) {
+                return eDataType.getInstanceClass() == TestPojoDataTypeImpl.class;
+            }
+        };
+        this.options.put(JsonResource.OPTION_SHOULD_EDATATYPE_BE_SERIALIZED_IN_JSON_PREDICATE, eDataTypeJsonSerializableTester);
+
+        this.testSave("NodeMultiValuedAttributePojoDataType.xmi"); //$NON-NLS-1$
     }
 
 }

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/model/TestPojoDataTypeImpl.java
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/model/TestPojoDataTypeImpl.java
@@ -1,0 +1,166 @@
+package model;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/*******************************************************************************
+ * Copyright (c) 2023 Obeo. All rights reserved. This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: Obeo - initial API and implementation
+ *******************************************************************************/
+
+public class TestPojoDataTypeImpl {
+
+    /**
+     * A String value.
+     */
+    private String stringValue = null;
+
+    /**
+     * An integer value.
+     */
+    private int intValue = 0;
+
+    /**
+     * Not serialized.
+     */
+    private transient int transientIntValue = 0;
+
+    /**
+     * Empty constructor for Json serialization.
+     *
+     */
+    public TestPojoDataTypeImpl() {
+
+    }
+
+    /**
+     * Returns the stringValue.
+     *
+     * @return The stringValue
+     */
+    public String getStringValue() {
+        return this.stringValue;
+    }
+
+    /**
+     * Sets the stringValue.
+     *
+     * @param stringValue
+     *            The stringValue to set
+     */
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    /**
+     * Returns the intValue.
+     *
+     * @return The intValue
+     */
+    public int getIntValue() {
+        return this.intValue;
+    }
+
+    /**
+     * Sets the intValue.
+     *
+     * @param intValue
+     *            The intValue to set
+     */
+    public void setIntValue(int intValue) {
+        this.intValue = intValue;
+    }
+
+    /**
+     * Returns the transientIntValue.
+     *
+     * @return The transientIntValue
+     */
+    public int getTransientIntValue() {
+        return this.transientIntValue;
+    }
+
+    /**
+     * Sets the transientIntValue.
+     *
+     * @param transientIntValue
+     *            The transientIntValue to set
+     */
+    public void setTransientIntValue(int transientIntValue) {
+        this.transientIntValue = transientIntValue;
+    }
+
+    /**
+     * Used by the XMI serialization. This doesn't produce as a Json string on purpose, not to interfere with the Json
+     * serialization.<br>
+     *
+     * @return A string representing this {@link TestPojoDataTypeImpl} instance.
+     */
+    @Override
+    public String toString() {
+        return String.format("TestPojoDataTypeImpl('%s', %d)", this.stringValue.replaceAll("'", "&apos;"), Integer.valueOf(this.intValue)); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    /**
+     * Used by the XMI deserialization. This doesn't take a Json string on purpose, not to interfere with the Json
+     * deserialization.
+     *
+     * @param serialized
+     *            The serialized form of a {@link TestPojoDataTypeImpl} as produced by
+     *            {@link TestPojoDataTypeImpl#toString()}.
+     * @return A new instance of {@link TestPojoDataTypeImpl} if the given serialized form is consistent, null
+     *         otherwise.
+     */
+    public static TestPojoDataTypeImpl valueOf(String serialized) {
+        TestPojoDataTypeImpl value = null;
+        Matcher matcher = Pattern.compile("TestPojoDataTypeImpl\\('([^']*)', ([0-9]+)\\)").matcher(serialized); //$NON-NLS-1$
+        if (matcher.matches()) {
+            value = new TestPojoDataTypeImpl();
+            value.setStringValue(matcher.group(1).replaceAll("&apos;", "'")); //$NON-NLS-1$ //$NON-NLS-2$
+            value.setIntValue(Integer.parseInt(matcher.group(2)));
+        }
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + this.intValue;
+        result = prime * result + ((this.stringValue == null) ? 0 : this.stringValue.hashCode());
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (this.getClass() != obj.getClass())
+            return false;
+        TestPojoDataTypeImpl other = (TestPojoDataTypeImpl) obj;
+        if (this.intValue != other.intValue)
+            return false;
+        if (this.stringValue == null) {
+            if (other.stringValue != null)
+                return false;
+        } else if (!this.stringValue.equals(other.stringValue))
+            return false;
+        return true;
+    }
+
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/nodes.ecore
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/nodes.ecore
@@ -61,6 +61,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="singleShortAttribute" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EShort"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="singleShortObjectAttribute"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EShortObject"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="singleTestPojoDataTypeAttribute"
+        eType="#//TestPojoDataType"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NodeMultiValuedAttribute" eSuperTypes="#//Node">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiStringAttribute" upperBound="-1"
@@ -105,6 +107,8 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EShort"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiShortObjectAttribute"
         upperBound="-1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EShortObject"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="multiPojoDataTypeAttribute"
+        upperBound="-1" eType="#//TestPojoDataType"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NodeSingleValueReference" eSuperTypes="#//Node">
     <eStructuralFeatures xsi:type="ecore:EReference" name="singleValuedReference"
@@ -171,4 +175,5 @@
   <eClassifiers xsi:type="ecore:EClass" name="OtherClass">
     <eTypeParameters name="aTypeParameter"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="TestPojoDataType" instanceClassName="model.TestPojoDataTypeImpl"/>
 </ecore:EPackage>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeMultiValuedAttributePojoDataType.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeMultiValuedAttributePojoDataType.json
@@ -1,0 +1,33 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeMultiValuedAttribute",
+      "data": {
+        "multiPojoDataTypeAttribute": [
+          {
+            "stringValue": "Eleven",
+            "intValue": 11
+          },
+          {
+            "stringValue": "Twelve",
+            "intValue": 12
+          },
+          {
+            "stringValue": "Forty two",
+            "intValue": 42
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeMultiValuedAttributePojoDataType.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeMultiValuedAttributePojoDataType.xmi
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeMultiValuedAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore">
+  <multiPojoDataTypeAttribute>TestPojoDataTypeImpl('Eleven', 11)</multiPojoDataTypeAttribute>
+  <multiPojoDataTypeAttribute>TestPojoDataTypeImpl('Twelve', 12)</multiPojoDataTypeAttribute>
+  <multiPojoDataTypeAttribute>TestPojoDataTypeImpl('Forty two', 42)</multiPojoDataTypeAttribute>
+</nodes:NodeMultiValuedAttribute>

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeSingleValueAttributePojoDataType.json
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeSingleValueAttributePojoDataType.json
@@ -1,0 +1,23 @@
+{
+  "json": {
+    "version": "1.0",
+    "encoding": "utf-8"
+  },
+  "ns": {
+    "nodes": "http://www.obeo.fr/EMFJson"
+  },
+  "schemaLocation": {
+    "http://www.obeo.fr/EMFJson": "../../../nodes.ecore"
+  },
+  "content": [
+    {
+      "eClass": "nodes:NodeSingleValueAttribute",
+      "data": {
+        "singleTestPojoDataTypeAttribute": {
+          "stringValue": "Twelve",
+          "intValue": 12
+        }
+      }
+    }
+  ]
+}

--- a/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeSingleValueAttributePojoDataType.xmi
+++ b/tests/org.eclipse.sirius.emfjson.tests/src/main/resources/unit/attributes/datatypes/NodeSingleValueAttributePojoDataType.xmi
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ASCII"?>
+<nodes:NodeSingleValueAttribute
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:nodes="http://www.obeo.fr/EMFJson"
+    xsi:schemaLocation="http://www.obeo.fr/EMFJson ../../../nodes.ecore"
+    singleTestPojoDataTypeAttribute="TestPojoDataTypeImpl('Twelve', 12)"/>


### PR DESCRIPTION
Addresses the following subjects:

- Handling the renaming of EAttribute
Renaming of EAttribute is handled by the `ExtendedMetaData.getElement()` API. Examples of such a migration is provided in the `org.eclipse.sirius.emfjson.tests.internal.unit.load.ExtendedMetaDataAttributesLoadTests` test class.

- Handling a type change or a value change of an EAttribute
Changing the type or the value of an EAttribute is handled with the `JsonHelper.setValue()` API. Exemple of such migrations are provided in the `org.eclipse.sirius.emfjson.tests.internal.unit.load.JsonHelperDataLoadTests` test class.

- Support for Serialization / deserialization of POJO EDataType
Custom data types with instance type set to a POJO class are serialized to / deserialized from json. The corresponding tests are :
`org.eclipse.sirius.emfjson.tests.internal.unit.load.DataTypeLoadTests.testLoadSingleValueAttributePojoDataType()`
`org.eclipse.sirius.emfjson.tests.internal.unit.load.DataTypeLoadTests.testLoadMultiValuedAttributePojoDataType()`
`org.eclipse.sirius.emfjson.tests.internal.unit.save.DataTypeSaveTests.testSaveSingleValueAttributePojoDataType()`
`org.eclipse.sirius.emfjson.tests.internal.unit.save.DataTypeSaveTests.testSaveMultiValuedAttributePojoDataType()`

- A comparator option on the JsonResource to determine the order in which features are serialized
`org.eclipse.sirius.emfjson.tests.internal.unit.save.SerializeOptionsTests.testSerializationWithFeatureOrderComparator()`
