### PR TITLE
[41] Do not delegate to EMF on failed id lookup

### DIFF
--- a/bundles/org.eclipse.sirius.emfjson.ide/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.sirius.emfjson.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.sirius.emfjson.ide;singleton:=true
-Bundle-Version: 2.3.10.qualifier
+Bundle-Version: 2.3.11.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: bundle
 Require-Bundle: org.eclipse.sirius.emfjson;bundle-version="2.1.0",

--- a/bundles/org.eclipse.sirius.emfjson.ide/pom.xml
+++ b/bundles/org.eclipse.sirius.emfjson.ide/pom.xml
@@ -18,13 +18,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.10-SNAPSHOT</version>
+		<version>2.3.11-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 	
 	
 	<artifactId>org.eclipse.sirius.emfjson.ide</artifactId>
-	<version>2.3.10-SNAPSHOT</version>
+	<version>2.3.11-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	
 	<name>Sirius EMF JSON - IDE Integration</name>

--- a/bundles/org.eclipse.sirius.emfjson/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.sirius.emfjson/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.sirius.emfjson
-Bundle-Version: 2.3.10.qualifier
+Bundle-Version: 2.3.11.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: bundle

--- a/bundles/org.eclipse.sirius.emfjson/pom.xml
+++ b/bundles/org.eclipse.sirius.emfjson/pom.xml
@@ -18,13 +18,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.10-SNAPSHOT</version>
+		<version>2.3.11-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 	
 	
 	<artifactId>org.eclipse.sirius.emfjson</artifactId>
-	<version>2.3.10-SNAPSHOT</version>
+	<version>2.3.11-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	
 	<name>Sirius EMF JSON</name>

--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResourceImpl.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResourceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Obeo.
+ * Copyright (c) 2020, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -57,7 +57,7 @@ public class JsonResourceImpl extends ResourceImpl implements JsonResource {
     /**
      * The options.
      */
-    private Map<Object, Object> resourceOptions = new HashMap<Object, Object>();
+    private Map<Object, Object> resourceOptions = new HashMap<>();
 
     /**
      * Use to know is an id is used to identified an EObject.
@@ -111,7 +111,7 @@ public class JsonResourceImpl extends ResourceImpl implements JsonResource {
      * @return the json representation of the given Resource
      */
     public static String toJson(Resource resource, Map<Object, Object> options) {
-        Map<Object, Object> loadOptions = new HashMap<Object, Object>();
+        Map<Object, Object> loadOptions = new HashMap<>();
         if (options != null) {
             loadOptions.putAll(options);
         }
@@ -444,12 +444,8 @@ public class JsonResourceImpl extends ResourceImpl implements JsonResource {
     @Override
     protected EObject getEObjectByID(String id) {
         if (this.useID) {
-            EObject eObject = this.idToEObjectMap.get(id);
-            if (eObject != null) {
-                return eObject;
-            }
+            return this.idToEObjectMap.get(id);
         }
-
         return super.getEObjectByID(id);
     }
 

--- a/features/org.eclipse.sirius.emfjson.feature.ide/feature.xml
+++ b/features/org.eclipse.sirius.emfjson.feature.ide/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sirius.emfjson.feature.ide"
       label="%Feature-name"
-      version="2.3.10.qualifier"
+      version="2.3.11.qualifier"
       provider-name="%Feature-vendor">
 
    <description url="">

--- a/features/org.eclipse.sirius.emfjson.feature.ide/pom.xml
+++ b/features/org.eclipse.sirius.emfjson.feature.ide/pom.xml
@@ -20,13 +20,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.10-SNAPSHOT</version>
+		<version>2.3.11-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 	
 	
 	<artifactId>org.eclipse.sirius.emfjson.feature.ide</artifactId>
-	<version>2.3.10-SNAPSHOT</version>
+	<version>2.3.11-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 	
 	<name>Sirius EMF JSON - IDE Integration Feature</name>

--- a/features/org.eclipse.sirius.emfjson.feature/feature.xml
+++ b/features/org.eclipse.sirius.emfjson.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.sirius.emfjson.feature"
       label="%Feature-name"
-      version="2.3.10.qualifier"
+      version="2.3.11.qualifier"
       provider-name="%Feature-vendor">
 
    <description url="">

--- a/features/org.eclipse.sirius.emfjson.feature/pom.xml
+++ b/features/org.eclipse.sirius.emfjson.feature/pom.xml
@@ -20,13 +20,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.10-SNAPSHOT</version>
+		<version>2.3.11-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 
 
 	<artifactId>org.eclipse.sirius.emfjson.feature</artifactId>
-	<version>2.3.10-SNAPSHOT</version>
+	<version>2.3.11-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Sirius EMF JSON Feature</name>

--- a/releng/org.eclipse.sirius.emfjson.releng/pom.xml
+++ b/releng/org.eclipse.sirius.emfjson.releng/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.eclipse.sirius.emfjson</groupId>
   <artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-  <version>2.3.10-SNAPSHOT</version>
+  <version>2.3.11-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Sirius EMF JSON</name>

--- a/releng/org.eclipse.sirius.emfjson.targetplatforms/2019-06/pom.xml
+++ b/releng/org.eclipse.sirius.emfjson.targetplatforms/2019-06/pom.xml
@@ -6,13 +6,13 @@
  <parent>
     <groupId>org.eclipse.sirius.emfjson</groupId>
   	<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-  	<version>2.3.10-SNAPSHOT</version>
+  	<version>2.3.11-SNAPSHOT</version>
     <relativePath>../../org.eclipse.sirius.emfjson.releng</relativePath>
   </parent>
 
   <groupId>org.eclipse.sirius.emfjson</groupId>
   <artifactId>emfjson-2019-06</artifactId>
-  <version>2.3.10-SNAPSHOT</version>
+  <version>2.3.11-SNAPSHOT</version>
   <packaging>eclipse-target-definition</packaging>
 
 </project>

--- a/releng/org.eclipse.sirius.emfjson.targetplatforms/luna/pom.xml
+++ b/releng/org.eclipse.sirius.emfjson.targetplatforms/luna/pom.xml
@@ -6,13 +6,13 @@
  <parent>
     <groupId>org.eclipse.sirius.emfjson</groupId>
   	<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-  	<version>2.3.10-SNAPSHOT</version>
+  	<version>2.3.11-SNAPSHOT</version>
     <relativePath>../../org.eclipse.sirius.emfjson.releng</relativePath>
   </parent>
 
   <groupId>org.eclipse.sirius.emfjson</groupId>
   <artifactId>emfjson-luna</artifactId>
-  <version>2.3.10-SNAPSHOT</version>
+  <version>2.3.11-SNAPSHOT</version>
   <packaging>eclipse-target-definition</packaging>
 
 </project>

--- a/repositories/org.eclipse.sirius.emfjson.repository/pom.xml
+++ b/repositories/org.eclipse.sirius.emfjson.repository/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.10-SNAPSHOT</version>
+		<version>2.3.11-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 

--- a/tests/org.eclipse.sirius.emfjson.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.sirius.emfjson.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.sirius.emfjson.tests
-Bundle-Version: 2.3.10.qualifier
+Bundle-Version: 2.3.11.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Localization: bundle

--- a/tests/org.eclipse.sirius.emfjson.tests/pom.xml
+++ b/tests/org.eclipse.sirius.emfjson.tests/pom.xml
@@ -20,13 +20,13 @@
 	<parent>
 		<groupId>org.eclipse.sirius.emfjson</groupId>
 		<artifactId>org.eclipse.sirius.emfjson.releng</artifactId>
-		<version>2.3.10-SNAPSHOT</version>
+		<version>2.3.11-SNAPSHOT</version>
 		<relativePath>../../releng/org.eclipse.sirius.emfjson.releng</relativePath>
 	</parent>
 
 
 	<artifactId>org.eclipse.sirius.emfjson.tests</artifactId>
-	<version>2.3.10-SNAPSHOT</version>
+	<version>2.3.11-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<name>Sirius EMF JSON - Tests</name>


### PR DESCRIPTION
EMF's default implementation is slow, and we can trust our own local
idToEObjectMap.

Bug: https://github.com/eclipse-sirius/sirius-emf-json/issues/41
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
