### PR TITLE
[41] Use EMF's intrinsicIDToEObjectMap if present

### DIFF
--- a/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResourceImpl.java
+++ b/bundles/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResourceImpl.java
@@ -444,7 +444,11 @@ public class JsonResourceImpl extends ResourceImpl implements JsonResource {
     @Override
     protected EObject getEObjectByID(String id) {
         if (this.useID) {
-            return this.idToEObjectMap.get(id);
+            EObject result = this.idToEObjectMap.get(id);
+            if (result == null && this.intrinsicIDToEObjectMap != null) {
+                result = this.intrinsicIDToEObjectMap.get(id);
+            }
+            return result;
         }
         return super.getEObjectByID(id);
     }


### PR DESCRIPTION
The previous commit (1f4402943) completely disabled EMF's default
getEObjectByID in favor of using our own JSONResourceImpl-specific id
map. However there are cases where we still want to lookup elements by
their intrinsic (modeled) id instead of the IDManager-provided one,
without incurring the cost of an eAllContents() on failure.

This change allows for this to work, as long as the JSONResourceImpl
has been setup with a non-null intrinsicIDToEObjectMap. For example
right after the resource creation:

  ((ResourceImpl) resource).setIntrinsicIDToEObjectMap(new HashMap<>());

Once this is done, any new object added to the resource will get its
intrinsic id cached in this map (see ResourceImpl.attachedHelper())
and JsonResourceImpl.getEObjectById will find it there (if present)
while still bypassing the whole eAllContents() search in
super.getEObjectByID(id).

Bug: https://github.com/eclipse-sirius/sirius-emf-json/issues/41
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
