### PR TITLE
[53] Add support for deploying on Maven Central

### DIFF
--- a/.github/workflows/maven-deploy-to-maven-central.yml
+++ b/.github/workflows/maven-deploy-to-maven-central.yml
@@ -1,0 +1,34 @@
+# This workflow will deploy Sirius EMF JSON to the sonatype
+# staging environment. This will NOT automatically publish the artifacts. An
+# authorized user must still manually close the staging repository first.
+
+name: Generate and Deploy to Sonatype
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
+        with:
+          distribution: temurin
+          java-version: 17
+          server-id: ossrh
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_PASSWORD
+          gpg-private-key: ${{ secrets.MYGPGKEY_SEC }}
+
+      - name: Publish to Apache Maven Central
+        run: ./mvnw -P MavenCentral deploy
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/org.eclipse.sirius.emfjson/pom.xml
+++ b/org.eclipse.sirius.emfjson/pom.xml
@@ -66,14 +66,15 @@ Obeo - initial API and implementation
       <version>2.16.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.0.0-jre</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>

--- a/org.eclipse.sirius.emfjson/pom.xml
+++ b/org.eclipse.sirius.emfjson/pom.xml
@@ -124,4 +124,60 @@ Obeo - initial API and implementation
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>MavenCentral</id>
+      <build>
+        <plugins>
+          <!-- Signing the artifacts -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.7</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Upload to Maven Central -->
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+
+      <!-- Central Repository deployment configuration -->
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Add a new workflow, for now only triggered manually, to build on deploy on Maven Central.

* Inspired from https://github.com/eclipse-aas4j/aas4j
* Uses the secrets added to our org by https://github.com/eclipse-sirius/.eclipsefdn/pull/15
