### PR TITLE
Only depend on Guava for the tests

### DIFF
--- a/org.eclipse.sirius.emfjson/pom.xml
+++ b/org.eclipse.sirius.emfjson/pom.xml
@@ -66,14 +66,15 @@ Obeo - initial API and implementation
       <version>2.16.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.0.0-jre</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>


### PR DESCRIPTION
Inspecting the generated SBOM reveals that the dependency to Guava pulls several unrelated stuff we don't use ourselves:

![Capture d’écran du 2025-01-28 10-42-42](https://github.com/user-attachments/assets/a5b3a3e5-0876-408d-b1dd-c24b93e27b99)

And for no good reason, as we only use Guava in our tests. Changinf the scope of the Guava dependency to `test` reduces our declared dependencies signigicantly:

![Capture d’écran du 2025-01-28 10-45-34](https://github.com/user-attachments/assets/f87735fd-4e28-4b26-a5ff-0a01cf1effad)
