### PR TITLE
[releng] Only depend on org.eclipse.emf.ecore.xmi for the tests

### DIFF
--- a/org.eclipse.sirius.emfjson/pom.xml
+++ b/org.eclipse.sirius.emfjson/pom.xml
@@ -61,14 +61,15 @@ Obeo - initial API and implementation
       <version>2.23.0</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.emf</groupId>
-      <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-      <version>2.16.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+      <version>2.16.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
