### PR TITLE
Version bump and dependency updates

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,34 @@
+= Changelog
+
+== v2.4.1
+
+This version focuses on dependency updates.
+
+=== Deprecation warning
+
+None.
+
+=== Breaking changes
+
+None.
+
+=== Dependency update
+
+- https://github.com/eclipse-sirius/sirius-emf-json/issues/60[#60] [releng] Update EMF dependencies.
+The following dependencies have been updated:
+
+* `org.eclipse.emf.common` from `2.21.0` to `2.31.0`
+* `org.eclipse.emf.ecore` from `2.23.0` to `2.37.0`
+* `org.eclipse.emf.ecore.xmi` from `2.16.0` to `2.38.0`
+
+- Switched to Google Guava 33.4.8 (from 32.0.0).
+Guava is only used by the test code, so this has no impact on the actual behavior.
+- The dependency to `org.eclipse.emf.ecore.xmi` is now internal and limited to the tests.
+
+=== Bug fixes
+
+None.
+
+=== New Features and Improvements
+
+None.

--- a/org.eclipse.sirius.emfjson/pom.xml
+++ b/org.eclipse.sirius.emfjson/pom.xml
@@ -18,7 +18,7 @@ Obeo - initial API and implementation
 
   <groupId>org.eclipse.sirius</groupId>
   <artifactId>org.eclipse.sirius.emfjson</artifactId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>2.4.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Sirius EMF JSON</name>

--- a/org.eclipse.sirius.emfjson/pom.xml
+++ b/org.eclipse.sirius.emfjson/pom.xml
@@ -74,7 +74,7 @@ Obeo - initial API and implementation
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
+      <version>33.4.8-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/org.eclipse.sirius.emfjson/src/test/java/org/eclipse/sirius/emfjson/tests/internal/AbstractEMFJsonTests.java
+++ b/org.eclipse.sirius.emfjson/src/test/java/org/eclipse/sirius/emfjson/tests/internal/AbstractEMFJsonTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Obeo.
+ * Copyright (c) 2020, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -66,12 +66,12 @@ public abstract class AbstractEMFJsonTests {
     /**
      * Serializations options.
      */
-    protected Map<Object, Object> options = new HashMap<Object, Object>();
+    protected Map<Object, Object> options = new HashMap<>();
 
     /**
      * Data saved by the serialization listener.
      */
-    protected Map<String, Object> listenerData = new HashMap<String, Object>();
+    protected Map<String, Object> listenerData = new HashMap<>();
 
     /**
      * Returns the path of the folder containing the models used during the tests of this class.
@@ -232,7 +232,7 @@ public abstract class AbstractEMFJsonTests {
     protected Resource getModelResource(String resourceName, boolean loadMetamodel) {
         Resource resource = null;
         if (loadMetamodel) {
-            ArrayList<EPackage> arrayList = new ArrayList<EPackage>();
+            ArrayList<EPackage> arrayList = new ArrayList<>();
             arrayList.add(this.loadMetaModel("/nodes.ecore")); //$NON-NLS-1$
             arrayList.add(this.loadMetaModel("/unit/references/noncontainment/extlibrary.ecore")); //$NON-NLS-1$
             if (!arrayList.isEmpty()) {
@@ -326,7 +326,7 @@ public abstract class AbstractEMFJsonTests {
      *
      * @author <a href="mailto:guillaume.coutable@obeo.fr">Guillaume Coutable</a>
      */
-    private static class ExtendedEqualityHelper extends EcoreUtil.EqualityHelper {
+    private static final class ExtendedEqualityHelper extends EcoreUtil.EqualityHelper {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/org.eclipse.sirius.emfjson/src/test/java/org/eclipse/sirius/emfjson/tests/internal/options/IDManagerOptionsTests.java
+++ b/org.eclipse.sirius.emfjson/src/test/java/org/eclipse/sirius/emfjson/tests/internal/options/IDManagerOptionsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Obeo.
+ * Copyright (c) 2020, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -85,7 +85,7 @@ public class IDManagerOptionsTests extends AbstractEMFJsonTests {
      *
      * @author gcoutable
      */
-    private class TestIDManager implements IDManager {
+    private final class TestIDManager implements IDManager {
         /**
          * If ePackage ID has been properly retrieved.
          */

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.eclipse.sirius</groupId>
-  <artifactId>org.eclipse.sirius.emfjson.parent</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+    <artifactId>org.eclipse.sirius.emfjson.parent</artifactId>
+	<version>2.4.1-SNAPSHOT</version>
 
 	<name>Sirius EMF JSON - Parent</name>
 	<packaging>pom</packaging>


### PR DESCRIPTION
- **[releng] Bump version to 2.4.1**
- **[cleanup] Fix CheckStyle warnings in the tests**
- **[doc] Add a top-level CHANGELOG**
- **[releng] Switch to Google Gson 2.12.1**
- **[releng] Switch to Guava 33.4.8**
