### PR TITLE
Sirius EMF JSON 2.5.0 (performance improvements)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,9 @@ For applications which depend on `EcoreUtil.getURI(eObject)` to return a (stable
 ----
 var resource = new JsonResourceImpl(uri, Map.of(JsonResource.OPTION_FORCE_DEFAULT_REFERENCE_SERIALIZATION, Boolean.TRUE));
 ----
+- The `org.eclipse.sirius.emfjson.resource.IDManager` interface has changed to allow for better performances:
+** The `clearId(EObject)` method used to expect the previous id of the object to be returned, but the result was not actually used. The method now returns `void` and implementations no longer need to return anything.
+** Symmetrically, the `setId(EObject, String)` method, which used to return `void`, should now return the previous id of the object, or `null` if there was none.
 
 === Dependency update
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,6 @@
 = Changelog
 
-== v2.5.0 (in progress)
+== v2.5.0
 
 This version focuses on performance improvements.
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,15 @@ None.
 
 === Breaking changes
 
-None.
+- https://github.com/eclipse-sirius/sirius-emf-json/issues/52[#52] The serialization format of inter-object references has changed to use the unique objet IDs by default (if an IDManager is configured and unless `OPTION_FORCE_DEFAULT_REFERENCE_SERIALIZATION` is `true`).
+For example a reference which was serialized as `"type": ""//supackage1/ClassSource_1/subclass.1"` before is now `"type": "6cfebaaa-fb15-41b5-b908-fa474b66b525"`.
+This changes the value returned by `EcoreUtil.getURI(eObject)` for objects inside JsonResource, which now return the object's ID instead of a path.
+For applications which depend on `EcoreUtil.getURI(eObject)` to return a (stable) path instead of a possibly random ID, the new behavior can be disabled by setting the `OPTION_FORCE_DEFAULT_REFERENCE_SERIALIZATION` option:
++
+[source,java]
+----
+var resource = new JsonResourceImpl(uri, Map.of(JsonResource.OPTION_FORCE_DEFAULT_REFERENCE_SERIALIZATION, Boolean.TRUE));
+----
 
 === Dependency update
 
@@ -23,6 +31,9 @@ None.
 === New Features and Improvements
 
 - Add a cache for qualified EClass names to avoid recomputing them many times when saving large resources.
+None.
+- https://github.com/eclipse-sirius/sirius-emf-json/issues/52[#52] Inter-object references now leverage the unique object IDs (instead of hierarchical URI fragments) by default, for *much* better performances, both on save and load.
+The performance improvements are only visible on resources saved using this version; resources saved using older version can still be loaded, but will not benefit from the change (until they are saved again).
 
 == v2.4.1
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,7 +22,7 @@ None.
 
 === New Features and Improvements
 
-None.
+- Add a cache for qualified EClass names to avoid recomputing them many times when saving large resources.
 
 == v2.4.1
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,29 @@
 = Changelog
 
+== v2.5.0 (in progress)
+
+This version focuses on performance improvements.
+
+=== Deprecation warning
+
+None.
+
+=== Breaking changes
+
+None.
+
+=== Dependency update
+
+None.
+
+=== Bug fixes
+
+None.
+
+=== New Features and Improvements
+
+None.
+
 == v2.4.1
 
 This version focuses on dependency updates.

--- a/org.eclipse.sirius.emfjson/pom.xml
+++ b/org.eclipse.sirius.emfjson/pom.xml
@@ -18,7 +18,7 @@ Obeo - initial API and implementation
 
   <groupId>org.eclipse.sirius</groupId>
   <artifactId>org.eclipse.sirius.emfjson</artifactId>
-  <version>2.4.1-SNAPSHOT</version>
+  <version>2.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Sirius EMF JSON</name>

--- a/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/IDManager.java
+++ b/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/IDManager.java
@@ -50,9 +50,8 @@ public interface IDManager {
      *
      * @param eObject
      *            The eObject
-     * @return The cleared ID or {@link Optional#empty()}
      */
-    Optional<String> clearId(EObject eObject);
+    void clearId(EObject eObject);
 
     /**
      * Sets the ID to the {@link EObject}.
@@ -66,6 +65,7 @@ public interface IDManager {
      *            The eObject to associate with the ID
      * @param id
      *            The ID to set in the eObject
+     * @return the previous id that was replaced, if there was one; <code>null</code> otherwise.
      */
-    void setId(EObject eObject, String id);
+    String setId(EObject eObject, String id);
 }

--- a/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResourceImpl.java
+++ b/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/resource/JsonResourceImpl.java
@@ -64,6 +64,8 @@ public class JsonResourceImpl extends ResourceImpl implements JsonResource {
      */
     private boolean useID;
 
+    private boolean useIDAsURIFragment;
+
     /**
      * The constructor. <br/>
      * If an instance of {@link IDManager} is found in the resourceOptions, the usage of Id is possible. The ID is
@@ -84,6 +86,11 @@ public class JsonResourceImpl extends ResourceImpl implements JsonResource {
             Object idManagerObject = this.resourceOptions.get(JsonResource.OPTION_ID_MANAGER);
             if (idManagerObject instanceof IDManager) {
                 this.useID = true;
+                if (this.resourceOptions.get(JsonResource.OPTION_FORCE_DEFAULT_REFERENCE_SERIALIZATION) instanceof Boolean optionValue && optionValue.booleanValue()) {
+                    this.useIDAsURIFragment = false;
+                } else {
+                    this.useIDAsURIFragment = true;
+                }
             }
         }
     }
@@ -163,7 +170,22 @@ public class JsonResourceImpl extends ResourceImpl implements JsonResource {
 
         return json;
     }
+    
+    @Override
+    public String getURIFragment(EObject eObject) {
+        String id = null;
 
+        if (this.useIDAsURIFragment) {
+            id = this.getID(eObject);
+        }
+
+        if (id != null) {
+            return id;
+        } else {
+            return super.getURIFragment(eObject);
+        }
+    }
+    
     /**
      * Serializes a collection of EObject into its json representation.
      *
@@ -434,6 +456,16 @@ public class JsonResourceImpl extends ResourceImpl implements JsonResource {
                 }
             }
         }
+    }
+    
+    public String getID(EObject eObject) {
+        if (this.useID) {
+            Object managerObject = this.resourceOptions.get(JsonResource.OPTION_ID_MANAGER);
+            if (managerObject instanceof IDManager idManager) {
+                return idManager.findId(eObject).orElse(null);
+            }
+        }
+        return null;
     }
 
     @Override

--- a/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/JsonHelper.java
+++ b/org.eclipse.sirius.emfjson/src/main/java/org/eclipse/sirius/emfjson/utils/JsonHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Obeo.
+ * Copyright (c) 2020, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -76,7 +76,7 @@ public class JsonHelper {
         protected List<String> getPrefixes(String uri) {
             List<String> result = JsonHelper.this.urisToPrefixes.get(uri);
             if (result == null) {
-                result = new ArrayList<String>();
+                result = new ArrayList<>();
                 JsonHelper.this.urisToPrefixes.put(uri, result);
             }
             return result;
@@ -123,7 +123,7 @@ public class JsonHelper {
     /**
      * Mapping between packages and nsPrefix.
      */
-    protected Map<EPackage, String> packages = new HashMap<EPackage, String>();
+    protected Map<EPackage, String> packages = new HashMap<>();
 
     /**
      * Mapping between package prefixes and package URIs.
@@ -133,7 +133,7 @@ public class JsonHelper {
     /**
      * Mapping between package URIs and package prefixes. Avoid URI conflict.
      */
-    protected Map<String, List<String>> urisToPrefixes = new HashMap<String, List<String>>();
+    protected Map<String, List<String>> urisToPrefixes = new HashMap<>();
 
     /**
      * The type that it will be used, when an AnySimpleType will be encountered.
@@ -198,10 +198,16 @@ public class JsonHelper {
     private boolean serializeFragmentReferencesAsXMIResource;
 
     /**
+     * Cache for qualified EClass names.
+     */
+    private final Map<EClass, String> qnameCache;
+
+    /**
      * The constructor.
      */
     public JsonHelper() {
         this.prefixesToURIs = new PrefixToURI();
+        this.qnameCache = new HashMap<>();
     }
 
     /**
@@ -276,7 +282,7 @@ public class JsonHelper {
             int count = 0;
             for (EObject root : rootsEObject) {
                 InternalEObject internalEObject = (InternalEObject) root;
-                List<String> uriFragmentPath = new ArrayList<String>();
+                List<String> uriFragmentPath = new ArrayList<>();
                 boolean stop = false;
                 for (InternalEObject container = internalEObject.eInternalContainer(); container != null && !stop; container = internalEObject.eInternalContainer()) {
                     uriFragmentPath.add(container.eURIFragmentSegment(internalEObject.eContainingFeature(), internalEObject));
@@ -373,8 +379,10 @@ public class JsonHelper {
      * @return NsName:name of an EClass
      */
     public String getQName(EClass eClass) {
-        String name = this.getName(eClass);
-        return this.getQName(eClass.getEPackage(), name);
+        return this.qnameCache.computeIfAbsent(eClass, klass -> {
+            String name = this.getName(klass);
+            return this.getQName(klass.getEPackage(), name);
+        });
     }
 
     /**
@@ -542,7 +550,7 @@ public class JsonHelper {
      * @return EPackage prefixes list
      */
     public List<String> getPrefixes(EPackage ePackage) {
-        List<String> result = new UniqueEList<String>();
+        List<String> result = new UniqueEList<>();
         result.add(this.getPrefix(ePackage));
         String namespace = ePackage.getNsURI();
         if (this.extendedMetaData != null) {
@@ -670,7 +678,7 @@ public class JsonHelper {
      * @return the packages
      */
     public EPackage[] packages() {
-        Map<String, EPackage> map = new TreeMap<String, EPackage>();
+        Map<String, EPackage> map = new TreeMap<>();
 
         // Sort and eliminate duplicates caused by having both a regular package and a demanded package for
         // the same nsURI.

--- a/org.eclipse.sirius.emfjson/src/test/java/org/eclipse/sirius/emfjson/tests/internal/options/IDManagerOptionsTests.java
+++ b/org.eclipse.sirius.emfjson/src/test/java/org/eclipse/sirius/emfjson/tests/internal/options/IDManagerOptionsTests.java
@@ -97,12 +97,13 @@ public class IDManagerOptionsTests extends AbstractEMFJsonTests {
         private boolean eClassIDRetrieved;
 
         @Override
-        public void setId(EObject eObject, String id) {
+        public String setId(EObject eObject, String id) {
             if (EcorePackage.eINSTANCE.getEPackage().equals(eObject.eClass())) {
                 this.ePackageIDRetrieved = IDManagerOptionsTests.MY_E_PACKAGE_ID.equals(id);
             } else if (EcorePackage.eINSTANCE.getEClass().equals(eObject.eClass())) {
                 this.eClassIDRetrieved = IDManagerOptionsTests.MY_E_CLASS_ID.equals(id);
             }
+            return null;
         }
 
         @Override
@@ -118,24 +119,14 @@ public class IDManagerOptionsTests extends AbstractEMFJsonTests {
             return id;
         }
 
-        /**
-         * {@inheritDoc}
-         *
-         * @see org.eclipse.sirius.emfjson.resource.IDManager#findId(org.eclipse.emf.ecore.EObject)
-         */
         @Override
         public Optional<String> findId(EObject eObject) {
             return Optional.ofNullable(this.getOrCreateId(eObject));
         }
 
-        /**
-         * {@inheritDoc}
-         *
-         * @see org.eclipse.sirius.emfjson.resource.IDManager#clearId(org.eclipse.emf.ecore.EObject)
-         */
         @Override
-        public Optional<String> clearId(EObject eObject) {
-            return Optional.empty();
+        public void clearId(EObject eObject) {
+         // Nothing to do.
         }
 
         /**

--- a/org.eclipse.sirius.emfjson/src/test/java/org/eclipse/sirius/emfjson/tests/internal/unit/RemoveObjectTests.java
+++ b/org.eclipse.sirius.emfjson/src/test/java/org/eclipse/sirius/emfjson/tests/internal/unit/RemoveObjectTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Obeo.
+ * Copyright (c) 2020, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -120,7 +120,7 @@ public class RemoveObjectTests {
     private JsonResource createJsonResource() {
         ResourceSet resourceSet = new ResourceSetImpl();
         resourceSet.getPackageRegistry().put(this.ePackage.getNsURI(), this.ePackage);
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new HashMap<>();
         options.put(JsonResource.OPTION_ID_MANAGER, new IDManager() {
             @Override
             public String getOrCreateId(EObject eObject) {
@@ -128,8 +128,10 @@ public class RemoveObjectTests {
             }
 
             @Override
-            public void setId(EObject eObject, String id) {
+            public String setId(EObject eObject, String id) {
+                String previousId = EcoreUtil.getID(eObject);
                 EcoreUtil.setID(eObject, id);
+                return previousId;
             }
 
             @Override
@@ -138,8 +140,8 @@ public class RemoveObjectTests {
             }
 
             @Override
-            public Optional<String> clearId(EObject eObject) {
-                return Optional.empty();
+            public void clearId(EObject eObject) {
+                // Nothing to do.
             }
         });
         return new JsonResourceImpl(URI.createURI(""), options); //$NON-NLS-1$

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
     <artifactId>org.eclipse.sirius.emfjson.parent</artifactId>
-	<version>2.4.1-SNAPSHOT</version>
+	<version>2.5.0-SNAPSHOT</version>
 
 	<name>Sirius EMF JSON - Parent</name>
 	<packaging>pom</packaging>


### PR DESCRIPTION
- **[doc] Prepare CHANGELOG for 2.5.0**
- **[releng] Bump version to 2.5.0**
- **[enh] Cache EClasses QNames**
- **[53] Leverage the ID from IDManager to compute URI fragments**
- **[enh] Rework IDManager API for better performance**
